### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 DAAP server for streaming media, built around the Flask micro framework. Supports iTunes, artwork and revisioning.
 
 [![Build Status](https://travis-ci.org/basilfx/flask-daapserver.svg?branch=master)](https://travis-ci.org/basilfx/flask-daapserver)
-[![Latest Version](https://pypip.in/version/flask-daapserver/badge.svg)](https://pypi.python.org/pypi/flask-daapserver/)
+[![Latest Version](https://img.shields.io/pypi/v/flask-daapserver.svg)](https://pypi.python.org/pypi/flask-daapserver/)
 
 ## Introduction.
 The Digital Audio Access Protocol (DAAP) is a protocol designed by Apple to share media over the network, using HTTP as transport layer. It advertises itself via Bonjour/Zeroconf.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-daapserver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-daapserver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.